### PR TITLE
fix: correct GitHub token environment variable name

### DIFF
--- a/scripts/create-digest.js
+++ b/scripts/create-digest.js
@@ -6,15 +6,21 @@ const OWNER = 'chikuma0';
 const REPO = 'daily-tech-digest';
 
 const gatherNews = async () => {
-  // Implement your news gathering logic here
+  // Default placeholder content until API integration
   const news = {
-    solopreneur: [],
-    aiTech: [],
-    japan: [],
-    insights: []
+    solopreneur: [
+      "* No updates today"
+    ],
+    aiTech: [
+      "* No updates today"
+    ],
+    japan: [
+      "* No updates today"
+    ],
+    insights: [
+      "* No updates today"
+    ]
   };
-
-  // Add your API calls here
 
   return news;
 };
@@ -29,14 +35,14 @@ const formatDigest = (news) => {
 const uploadDigest = async (path, content) => {
   const url = `${BASE_URL}/repos/${OWNER}/${REPO}/contents/${path}`;
   const data = {
-    message: `Addday's digest`,
+    message: `Add today's digest`,
     content: Buffer.from(content).toString('base64')
   };
 
   try {
     await axios.put(url, data, {
       headers: {
-        Authorization: `token ${process.env.GITHWB_TOKEN}`,
+        Authorization: `token ${process.env.GITHUB_TOKEN}`,
         Accept: 'application/vnd.github.v3+json'
       }
     });


### PR DESCRIPTION
This PR fixes two issues:

1. Corrects the GitHub token environment variable name from `GITHWB_TOKEN` to `GITHUB_TOKEN`
2. Adds placeholder content to the `gatherNews` function to prevent empty digest creation

These changes should resolve the authentication errors in the GitHub Actions workflow.